### PR TITLE
Improve async progress display with separate discovery and status bars

### DIFF
--- a/src/gitoverit/cli.py
+++ b/src/gitoverit/cli.py
@@ -11,7 +11,7 @@ from rich.console import Console
 
 from .output import render_json, render_table
 from .progress import RichHook
-from .reporting import RepoReport, collect_reports, collect_reports_parallel
+from .reporting import RepoReport, collect_reports_parallel
 
 console = Console()
 
@@ -68,18 +68,13 @@ def cli(
 
     hook = RichHook(console) if _stdout_is_tty() else None
 
-    # Use sequential mode only if explicitly set to 0
-    if parallel == 0:
-        reports = collect_reports(dirs, fetch=fetch, dirty_only=dirty_only, hook=hook)
-    else:
-        # Default: parallel mode with auto-detect (None) or specified worker count
-        reports = collect_reports_parallel(
-            dirs,
-            fetch=fetch,
-            dirty_only=dirty_only,
-            hook=hook,
-            max_workers=parallel  # None means auto-detect, or use specified count
-        )
+    reports = collect_reports_parallel(
+        dirs,
+        fetch=fetch,
+        dirty_only=dirty_only,
+        hook=hook,
+        max_workers=parallel,  # None means auto-detect, 0 means sequential, N means N workers
+    )
 
     _sort_reports(reports, sort=sort, reverse=reverse)
 

--- a/src/gitoverit/progress.py
+++ b/src/gitoverit/progress.py
@@ -32,6 +32,7 @@ class HookProtocol(Protocol):
 class RichHook(HookProtocol):
     def __init__(self, console: Console) -> None:
         self.console = console
+        self._closed = False
         self.progress = Progress(
             TextColumn("{task.description}"),
             BarColumn(bar_width=None),
@@ -128,9 +129,16 @@ class RichHook(HookProtocol):
         self.error_count += 1
 
     def done(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+
         if self.discovery_task_id is not None:
             self.progress.remove_task(self.discovery_task_id)
             self.discovery_task_id = None
+        if self.status_task_id is not None:
+            self.progress.remove_task(self.status_task_id)
+            self.status_task_id = None
         self.progress.__exit__(None, None, None)
 
 

--- a/src/gitoverit/progress.py
+++ b/src/gitoverit/progress.py
@@ -7,7 +7,6 @@ from rich.console import Console
 from rich.progress import (
     BarColumn,
     Progress,
-    SpinnerColumn,
     TaskID,
     TaskProgressColumn,
     TextColumn,
@@ -19,9 +18,13 @@ class HookProtocol(Protocol):
     """Simple progress notification protocol - no flow control"""
     def discovering(self, path: Path) -> None: ...
 
+    def discovery_done(self) -> None: ...
+
     def start_collect(self, total: int) -> None: ...
 
     def collecting(self, index: int, path: Path) -> None: ...
+
+    def error(self, path: Path) -> None: ...
 
     def done(self) -> None: ...
 
@@ -30,7 +33,6 @@ class RichHook(HookProtocol):
     def __init__(self, console: Console) -> None:
         self.console = console
         self.progress = Progress(
-            SpinnerColumn(),
             TextColumn("{task.description}"),
             BarColumn(bar_width=None),
             TaskProgressColumn(),
@@ -40,44 +42,90 @@ class RichHook(HookProtocol):
         )
         self.progress.__enter__()
         self.discovery_task_id: TaskID | None = self.progress.add_task(
-            "[cyan]Discovering repositories...", total=None
+            "[cyan]Repo discovery", total=None
+        )
+        self.status_task_id: TaskID | None = self.progress.add_task(
+            "[cyan]Repo statusing", total=1, visible=False
         )
         self.discovered_count = 0
-        self.gather_task_id: TaskID | None = None
+        self.discovery_finished = False
         self.total_to_collect = 0
         self.error_count = 0  # Add error tracking for parallel mode
 
     def discovering(self, path: Path) -> None:
+        if self.discovery_finished:
+            return
         self.discovered_count += 1
         if self.discovery_task_id is not None:
             description = (
-                f"[cyan]Discovering repositories ({self.discovered_count})"
+                f"[cyan]Repo discovery ({self.discovered_count})"
             )
             self.progress.update(self.discovery_task_id, description=description)
 
-    def start_collect(self, total: int) -> None:
-        self.total_to_collect = total
-        if self.discovery_task_id is not None:
+        if self.status_task_id is not None:
+            self.progress.update(
+                self.status_task_id,
+                total=self.discovered_count,
+                visible=True,
+            )
+
+    def discovery_done(self) -> None:
+        self.discovery_finished = True
+        if self.discovery_task_id is None:
+            return
+
+        if self.discovered_count <= 0:
+            # No repos discovered; avoid a misleading 1/1 style display.
             self.progress.remove_task(self.discovery_task_id)
             self.discovery_task_id = None
-        if total <= 0:
             return
-        self.gather_task_id = self.progress.add_task(
-            "[cyan]Gathering status...", total=total
+
+        self.progress.update(
+            self.discovery_task_id,
+            total=self.discovered_count,
+            completed=self.discovered_count,
+            description=f"[green]Repo discovery done ({self.discovered_count})",
         )
 
-    def collecting(self, index: int, path: Path) -> None:
-        if self.gather_task_id is not None:
-            display_name = path.name or str(path)
-            error_text = f" [red]({self.error_count} errors)[/red]" if self.error_count > 0 else ""
-            description = (
-                f"[cyan]Gathering status ({index}/{self.total_to_collect}): {display_name}{error_text}"
+    def start_collect(self, total: int) -> None:
+        effective_total = max(total, self.discovered_count)
+        self.total_to_collect = effective_total
+
+        if self.status_task_id is None:
+            self.status_task_id = self.progress.add_task(
+                "[cyan]Repo statusing", total=max(effective_total, 1), visible=effective_total > 0
             )
+            return
+
+        if effective_total > 0:
             self.progress.update(
-                self.gather_task_id,
-                advance=1,
-                description=description,
+                self.status_task_id,
+                total=effective_total,
+                visible=True,
             )
+
+    def collecting(self, index: int, path: Path) -> None:
+        if self.status_task_id is None:
+            return
+
+        effective_total = max(self.total_to_collect, self.discovered_count)
+        self.total_to_collect = effective_total
+
+        display_name = path.name or str(path)
+        error_text = (
+            f" [red]({self.error_count} errors)[/red]" if self.error_count > 0 else ""
+        )
+        description = f"[cyan]Repo statusing: {display_name}{error_text}"
+        self.progress.update(
+            self.status_task_id,
+            total=max(effective_total, 1),
+            completed=index,
+            visible=effective_total > 0,
+            description=description,
+        )
+
+    def error(self, path: Path) -> None:
+        self.error_count += 1
 
     def done(self) -> None:
         if self.discovery_task_id is not None:

--- a/src/gitoverit/reporting.py
+++ b/src/gitoverit/reporting.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import re
-from concurrent.futures import Future, ProcessPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, Future, ProcessPoolExecutor, wait
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Iterable, Iterator, Sequence
@@ -68,24 +68,27 @@ def collect_reports(
     repo_paths: list[Path] = []
 
     try:
+        if hook:
+            hook.start_collect(0)
+
         for repo_path in discover_repositories(dirs):
             if hook:
                 hook.discovering(repo_path)
             repo_paths.append(repo_path)
 
-        if repo_paths:
-            if hook:
-                hook.start_collect(len(repo_paths))
+        if hook:
+            hook.discovery_done()
+            hook.start_collect(len(repo_paths))
 
-            for index, repo_path in enumerate(repo_paths, start=1):
-                report = analyze_repository(repo_path, fetch=fetch)
-                include = not (
-                    dirty_only and not report.dirty and not report.fetch_failed
-                )
-                if include:
-                    reports.append(report)
-                if hook:
-                    hook.collecting(index, repo_path)
+        for index, repo_path in enumerate(repo_paths, start=1):
+            report = analyze_repository(repo_path, fetch=fetch)
+            include = not (
+                dirty_only and not report.dirty and not report.fetch_failed
+            )
+            if include:
+                reports.append(report)
+            if hook:
+                hook.collecting(index, repo_path)
     finally:
         if hook is not None:
             hook.done()
@@ -116,47 +119,70 @@ def collect_reports_parallel(
     """Parallel version of collect_reports with streaming discovery"""
 
     reports: list[RepoReport] = []
-    error_count = 0
+    discovered_total = 0
+    statused_total = 0
 
-    with ProcessPoolExecutor(max_workers=get_worker_count(max_workers)) as executor:
-        # Phase 1: Stream discovery - submit repos to pool as we find them
-        futures: dict[Future[RepoReport], Path] = {}
-
-        for repo_path in discover_repositories(dirs):
-            if hook:
-                hook.discovering(repo_path)
-
-            # Submit immediately - workers start processing while discovery continues
-            future = executor.submit(analyze_repository, repo_path, fetch)
-            futures[future] = repo_path
-
-        # Discovery complete - now we know the total count
-        if not futures:
-            if hook:
-                hook.done()
-            return []
-
+    try:
         if hook:
-            hook.start_collect(len(futures))
+            hook.start_collect(0)
 
-        # Phase 2: Collect results as they complete
-        for completed, future in enumerate(as_completed(futures), 1):
-            path = futures[future]
+        worker_count = get_worker_count(max_workers)
+        max_pending = max(1, worker_count * 4)
 
-            try:
-                report = future.result()  # Will raise if worker raised
-                if not (dirty_only and not report.dirty and not report.fetch_failed):
-                    reports.append(report)
-            except Exception as e:
-                # Worker raised an exception - log it but continue
-                error_count += 1
-                # Could log: print(f"Failed to analyze {path}: {e}")
+        discovery_finished = False
+        with ProcessPoolExecutor(max_workers=worker_count) as executor:
+            repo_iter = iter(discover_repositories(dirs))
+            futures: dict[Future[RepoReport], Path] = {}
 
-            if hook:
-                hook.collecting(completed, path)
+            while True:
+                while not discovery_finished and len(futures) < max_pending:
+                    try:
+                        repo_path = next(repo_iter)
+                    except StopIteration:
+                        discovery_finished = True
+                        if hook:
+                            hook.discovery_done()
+                            hook.start_collect(discovered_total)
+                        break
 
-    if hook:
-        hook.done()
+                    discovered_total += 1
+                    if hook:
+                        hook.discovering(repo_path)
+
+                    future = executor.submit(analyze_repository, repo_path, fetch)
+                    futures[future] = repo_path
+
+                if not futures:
+                    if discovery_finished:
+                        break
+                    continue
+
+                completed, _ = wait(
+                    futures,
+                    timeout=0.1,
+                    return_when=FIRST_COMPLETED,
+                )
+                for future in completed:
+                    path = futures.pop(future)
+                    statused_total += 1
+                    try:
+                        report = future.result()
+                        if not (
+                            dirty_only and not report.dirty and not report.fetch_failed
+                        ):
+                            reports.append(report)
+                    except Exception:
+                        if hook:
+                            hook.error(path)
+                    if hook:
+                        hook.collecting(statused_total, path)
+
+        if hook and not discovery_finished:
+            hook.discovery_done()
+            hook.start_collect(discovered_total)
+    finally:
+        if hook:
+            hook.done()
 
     return reports
 


### PR DESCRIPTION
- Add discovery_done() and error() hooks to protocol
- Show two distinct progress bars: repo discovery and repo statusing
- Use backpressure in parallel mode (max_pending = workers * 4)
- Remove SpinnerColumn for cleaner progress display