### PR TITLE
add include-ignored option for nested repos

### DIFF
--- a/src/gitoverit/cli.py
+++ b/src/gitoverit/cli.py
@@ -149,6 +149,12 @@ def cli(
     dirty_only: bool = typer.Option(
         False, "-d", "--dirty-only", help="Display only repositories with uncommitted local changes."
     ),
+    include_ignored: bool = typer.Option(
+        False,
+        "-I",
+        "--include-ignored",
+        help="Include nested repositories even when ignored by a parent repository.",
+    ),
     sort: SortMode = typer.Option(
         SortMode.MTIME,
         "-s", "--sort",
@@ -225,6 +231,7 @@ def cli(
         dirs,
         fetch=fetch,
         dirty_only=dirty_only,
+        include_ignored=include_ignored,
         hook=hook,
         max_workers=parallel,  # None means auto-detect, 0 means sequential, N means N workers
     )

--- a/src/gitoverit/reporting.py
+++ b/src/gitoverit/reporting.py
@@ -72,6 +72,7 @@ def collect_reports(
     *,
     fetch: bool,
     dirty_only: bool,
+    include_ignored: bool = False,
     hook: HookProtocol | None = None,
 ) -> list[RepoReport]:
     # Backwards-compatible wrapper for sequential runs.
@@ -79,6 +80,7 @@ def collect_reports(
         dirs,
         fetch=fetch,
         dirty_only=dirty_only,
+        include_ignored=include_ignored,
         hook=hook,
         max_workers=0,
     )
@@ -101,6 +103,7 @@ def collect_reports_parallel(
     *,
     fetch: bool,
     dirty_only: bool,
+    include_ignored: bool = False,
     hook: HookProtocol | None = None,
     max_workers: int | None = None,
 ) -> list[RepoReport]:
@@ -117,7 +120,10 @@ def collect_reports_parallel(
         worker_count = get_worker_count(max_workers)
         if worker_count == 0:
             repo_paths: list[Path] = []
-            for repo_path in discover_repositories(dirs):
+            for repo_path in discover_repositories(
+                dirs,
+                include_ignored=include_ignored,
+            ):
                 discovered_total += 1
                 if hook:
                     hook.discovering(repo_path)
@@ -148,7 +154,12 @@ def collect_reports_parallel(
 
         discovery_finished = False
         with ThreadPoolExecutor(max_workers=worker_count) as executor:
-            repo_iter = iter(discover_repositories(dirs))
+            repo_iter = iter(
+                discover_repositories(
+                    dirs,
+                    include_ignored=include_ignored,
+                )
+            )
             futures: dict[Future[RepoReport], Path] = {}
 
             while True:
@@ -200,7 +211,11 @@ def collect_reports_parallel(
     return reports
 
 
-def discover_repositories(roots: Iterable[Path]) -> Iterator[Path]:
+def discover_repositories(
+    roots: Iterable[Path],
+    *,
+    include_ignored: bool = False,
+) -> Iterator[Path]:
     seen: set[Path] = set()
     known_repos: list[Path] = []
     normalized_roots = [root.resolve() for root in roots]
@@ -216,7 +231,10 @@ def discover_repositories(roots: Iterable[Path]) -> Iterator[Path]:
                     continue
                 resolved = current.resolve()
                 if resolved not in seen:
-                    if _is_gitignored_by_parent(resolved, known_repos):
+                    if not include_ignored and _is_gitignored_by_parent(
+                        resolved,
+                        known_repos,
+                    ):
                         dirnames[:] = []
                         continue
                     seen.add(resolved)

--- a/tests/test_gitoverit.py
+++ b/tests/test_gitoverit.py
@@ -164,6 +164,27 @@ class DiscoverRepositoriesTests(unittest.TestCase):
             self.assertIn(parent.resolve(), resolved_paths)
             self.assertNotIn(nested.resolve(), resolved_paths)
 
+    def test_gitignored_nested_repo_is_found_with_include_ignored(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            parent = Path(tmpdir) / "parent"
+            parent.mkdir()
+            parent_repo = Repo.init(parent)
+
+            gitignore = parent / ".gitignore"
+            gitignore.write_text("nested/\n")
+            parent_repo.index.add([".gitignore"])
+            author = Actor("Tester", "tester@example.com")
+            parent_repo.index.commit("init", author=author, committer=author)
+
+            nested = parent / "nested"
+            nested.mkdir()
+            Repo.init(nested)
+
+            discovered = list(discover_repositories([parent], include_ignored=True))
+            resolved_paths = [p.resolve() for p in discovered]
+            self.assertIn(parent.resolve(), resolved_paths)
+            self.assertIn(nested.resolve(), resolved_paths)
+
     def test_non_gitignored_nested_repo_is_found(self) -> None:
         with TemporaryDirectory() as tmpdir:
             parent = Path(tmpdir) / "parent"
@@ -201,6 +222,27 @@ class DiscoverRepositoriesTests(unittest.TestCase):
             resolved_paths = [p.resolve() for p in discovered]
             self.assertIn(parent.resolve(), resolved_paths)
             self.assertNotIn(vendor_lib.resolve(), resolved_paths)
+
+    def test_deeply_nested_under_gitignored_is_found_with_include_ignored(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            parent = Path(tmpdir) / "parent"
+            parent.mkdir()
+            parent_repo = Repo.init(parent)
+
+            gitignore = parent / ".gitignore"
+            gitignore.write_text("vendor/\n")
+            parent_repo.index.add([".gitignore"])
+            author = Actor("Tester", "tester@example.com")
+            parent_repo.index.commit("init", author=author, committer=author)
+
+            vendor_lib = parent / "vendor" / "lib"
+            vendor_lib.mkdir(parents=True)
+            Repo.init(vendor_lib)
+
+            discovered = list(discover_repositories([parent], include_ignored=True))
+            resolved_paths = [p.resolve() for p in discovered]
+            self.assertIn(parent.resolve(), resolved_paths)
+            self.assertIn(vendor_lib.resolve(), resolved_paths)
 
 
 class FilterReportsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Add `-I` / `--include-ignored` to include nested repositories even when a parent repository ignores their path.

Fixes #2.

## Why
`discover_repositories()` currently skips nested repos when the nearest parent repo reports their path as gitignored. That hides legitimate nested repositories in monorepo-style layouts with ignore rules for child repo directories.

## User impact
Users can keep the existing default behavior, or opt in to seeing ignored nested repos with `gitoverit --include-ignored`.

## Root cause
Nested repository discovery always applied the parent `.gitignore` check, with no CLI escape hatch.

## Validation
- `uv run tasks/test`
- `uv run gitoverit --help`
