### PR TITLE
support sorting by all report columns

### DIFF
--- a/src/gitoverit/cli.py
+++ b/src/gitoverit/cli.py
@@ -31,7 +31,16 @@ class OutputFormat(str, Enum):
 
 
 class SortMode(str, Enum):
+    DIR = "dir"
+    PATH = "path"
+    NAME = "name"
+    STATUS = "status"
+    BRANCH_REMOTE = "branch_remote"
+    BRANCH = "branch"
+    REMOTE = "remote"
+    URL = "url"
     MTIME = "mtime"
+    IDENT = "ident"
     AUTHOR = "author"
     NONE = "none"
 
@@ -153,7 +162,7 @@ def cli(
         SortMode.MTIME,
         "-s", "--sort",
         case_sensitive=False,
-        help="Sort repositories by mtime (default), author, or disable sorting with none",
+        help="Sort repositories by any supported field; default is mtime.",
     ),
     reverse: bool = typer.Option(
         False,
@@ -317,15 +326,36 @@ def _print_reports(
 
 
 def _sort_reports(reports: List[RepoReport], *, sort: SortMode, reverse: bool) -> None:
+    if sort is SortMode.NONE:
+        if reverse:
+            reports.reverse()
+        return
+
+    reports.sort(key=lambda report: _report_sort_key(report, sort), reverse=reverse)
+
+
+def _report_sort_key(report: RepoReport, sort: SortMode) -> object:
+    if sort is SortMode.DIR:
+        return report.display_path.casefold()
+    if sort is SortMode.PATH:
+        return str(report.path).casefold()
+    if sort is SortMode.NAME:
+        return report.path.name.casefold()
+    if sort is SortMode.STATUS:
+        return render_status_segments(report.status_segments).casefold()
+    if sort is SortMode.BRANCH_REMOTE:
+        return (report.branch.casefold(), report.remote.casefold())
+    if sort is SortMode.BRANCH:
+        return report.branch.casefold()
+    if sort is SortMode.REMOTE:
+        return report.remote.casefold()
+    if sort is SortMode.URL:
+        return report.remote_url.casefold()
     if sort is SortMode.MTIME:
-        reports.sort(key=lambda report: report.latest_mtime or 0.0, reverse=reverse)
-    elif sort is SortMode.AUTHOR:
-        reports.sort(
-            key=lambda report: (report.ident or "").lower(),
-            reverse=reverse,
-        )
-    elif reverse:
-        reports.reverse()
+        return report.latest_mtime or 0.0
+    if sort in {SortMode.IDENT, SortMode.AUTHOR}:
+        return (report.ident or "").casefold()
+    raise ValueError(f"Unsupported sort mode: {sort}")
 
 
 def _emit_errors(errors: list[tuple[Path, TracebackException | None]]) -> None:

--- a/tests/test_gitoverit.py
+++ b/tests/test_gitoverit.py
@@ -7,7 +7,7 @@ from tempfile import TemporaryDirectory
 
 from git import Actor, Repo
 
-from gitoverit.cli import _filter_reports, _print_reports
+from gitoverit.cli import SortMode, _filter_reports, _print_reports, _sort_reports
 from gitoverit.output.table import DEFAULT_COLUMNS, parse_columns
 from gitoverit.reporting import (
     ParsedStatus,
@@ -293,6 +293,108 @@ class FilterReportsTests(unittest.TestCase):
         """dirty should be False when only ahead/behind are set."""
         report = self._make_report(ahead=5, behind=2)
         self.assertFalse(report.dirty)
+
+
+class SortReportsTests(unittest.TestCase):
+    def _make_report(self, **kwargs: object) -> RepoReport:
+        defaults: dict[str, object] = dict(
+            path=Path("/tmp/repo"),
+            display_path="repo",
+            fetch_failed=False,
+            status_segments=[],
+            branch="main",
+            remote="-",
+            remote_url="-",
+            ident=None,
+            dirty=False,
+            latest_mtime=None,
+        )
+        defaults.update(kwargs)
+        return RepoReport(**defaults)  # type: ignore[arg-type]
+
+    def test_supported_sort_modes(self) -> None:
+        reports = [
+            self._make_report(
+                display_path="bravo/repo-b",
+                path=Path("/tmp/zulu/repo-b"),
+                branch="main",
+                remote="origin/main",
+                remote_url="github.com/example/repo-b",
+                ident="Zed <zed@example.com>",
+                latest_mtime=20.0,
+            ),
+            self._make_report(
+                display_path="alpha/repo-c",
+                path=Path("/tmp/alpha/repo-c"),
+                status_segments=[("2m", "yellow", "core")],
+                branch="feature",
+                remote="-",
+                remote_url="-",
+                ident="Amy <amy@example.com>",
+                latest_mtime=10.0,
+            ),
+            self._make_report(
+                display_path="charlie/repo-a",
+                path=Path("/tmp/beta/repo-a"),
+                status_segments=[("1u", "red", "core")],
+                branch="dev",
+                remote="upstream/dev",
+                remote_url="example.com/repo-a",
+                ident=None,
+                latest_mtime=None,
+            ),
+        ]
+
+        expected_orders = {
+            SortMode.DIR: ["alpha/repo-c", "bravo/repo-b", "charlie/repo-a"],
+            SortMode.PATH: ["alpha/repo-c", "charlie/repo-a", "bravo/repo-b"],
+            SortMode.NAME: ["charlie/repo-a", "bravo/repo-b", "alpha/repo-c"],
+            SortMode.STATUS: ["charlie/repo-a", "alpha/repo-c", "bravo/repo-b"],
+            SortMode.BRANCH_REMOTE: ["charlie/repo-a", "alpha/repo-c", "bravo/repo-b"],
+            SortMode.BRANCH: ["charlie/repo-a", "alpha/repo-c", "bravo/repo-b"],
+            SortMode.REMOTE: ["alpha/repo-c", "bravo/repo-b", "charlie/repo-a"],
+            SortMode.URL: ["alpha/repo-c", "charlie/repo-a", "bravo/repo-b"],
+            SortMode.MTIME: ["charlie/repo-a", "alpha/repo-c", "bravo/repo-b"],
+            SortMode.IDENT: ["charlie/repo-a", "alpha/repo-c", "bravo/repo-b"],
+            SortMode.AUTHOR: ["charlie/repo-a", "alpha/repo-c", "bravo/repo-b"],
+        }
+
+        self.assertEqual(
+            set(expected_orders),
+            set(SortMode) - {SortMode.NONE},
+        )
+
+        for sort_mode, expected in expected_orders.items():
+            ordered = list(reports)
+            _sort_reports(ordered, sort=sort_mode, reverse=False)
+            self.assertEqual(
+                [report.display_path for report in ordered],
+                expected,
+                msg=f"unexpected order for {sort_mode.value}",
+            )
+
+    def test_reverse_sort_applies_to_selected_mode(self) -> None:
+        reports = [
+            self._make_report(display_path="b", path=Path("/tmp/b")),
+            self._make_report(display_path="a", path=Path("/tmp/a")),
+            self._make_report(display_path="c", path=Path("/tmp/c")),
+        ]
+
+        _sort_reports(reports, sort=SortMode.DIR, reverse=True)
+        self.assertEqual([report.display_path for report in reports], ["c", "b", "a"])
+
+    def test_reverse_without_sort_reverses_current_order(self) -> None:
+        reports = [
+            self._make_report(display_path="first"),
+            self._make_report(display_path="second"),
+            self._make_report(display_path="third"),
+        ]
+
+        _sort_reports(reports, sort=SortMode.NONE, reverse=True)
+        self.assertEqual(
+            [report.display_path for report in reports],
+            ["third", "second", "first"],
+        )
 
 
 class PrintReportsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Expand `--sort` so it can order repositories by every report/table-facing field, while keeping the existing `author` sort and adding `path` and `name` aliases.

Fixes #3.

## Why
The original sort options only covered `mtime` and `author`, which made it awkward to find repositories by location, name, branch, remote, or other fields already shown by the tool.

## User impact
Users can now sort by `dir`, `path`, `name`, `status`, `branch_remote`, `branch`, `remote`, `url`, `mtime`, `ident`, `author`, or `none`.

## Root cause
Sorting was hardcoded to two modes in `cli.py`, instead of using the broader set of report fields that the CLI already exposes.

## Validation
- `uv run tasks/test`
- `uv run gitoverit --help`
