### PR TITLE
[codex] add safe pull mode for behind repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ If no directory is given, the current directory is used. Run with `-h` for the o
 
 ```
 -f, --fetch                Run `git fetch --all` for each repo before inspection.
+    --pull-safe            Fetch first, then run `git pull --ff-only` only for
+                           repos that are behind, not ahead, and otherwise clean.
 -o, --format {table,json}  Output format. Default: table.
 -d, --dirty-only           Hide repos with no uncommitted changes.
 -s, --sort {mtime,author,none}
@@ -93,6 +95,9 @@ gitoverit ~/projects -d -s author
 # Fetch first, then output JSON
 gitoverit ~/projects -f -o json
 
+# Safely fast-forward repos that are behind upstream
+gitoverit ~/projects --pull-safe
+
 # Repos on a non-main branch with unpushed commits
 gitoverit ~/projects -w 'branch != "main" and ahead > 0'
 
@@ -125,6 +130,10 @@ Pull every repo that's behind its tracking branch, clean, and not ahead:
 gitoverit ~/projects -f -w 'behind and not ahead and not dirty' -p path -0 \
   | xargs -0 -I{} git -C {} pull
 ```
+
+`--pull-safe` only pulls repos that are in a state where pulling is unlikely
+to create merge conflicts. To pull more aggressively, use the `-p` + `xargs`
+recipe above.
 
 List repos that have diverged (commits in both directions) so you can
 resolve them by hand:

--- a/src/gitoverit/cli.py
+++ b/src/gitoverit/cli.py
@@ -6,7 +6,7 @@ import sys
 from enum import Enum
 from pathlib import Path
 from traceback import TracebackException
-from typing import Annotated, List, Optional
+from typing import Annotated, List, Optional, TypeAlias
 
 import typer
 from rich.console import Console
@@ -17,6 +17,8 @@ from .progress import RichHook, SilentHook
 from .reporting import RepoReport, collect_reports_parallel, render_status_segments
 
 console = Console()
+
+SortKey: TypeAlias = str | float | tuple[str, str]
 
 APP = typer.Typer(
     add_completion=False,
@@ -152,6 +154,11 @@ def cli(
     fetch: bool = typer.Option(
         False, "-f", "--fetch", help="Run git fetch --all for each repository before inspection."
     ),
+    pull_safe: bool = typer.Option(
+        False,
+        "--pull-safe",
+        help="Fetch and fast-forward only clean, non-diverged repositories that are behind upstream.",
+    ),
     output_format: OutputFormat = typer.Option(
         OutputFormat.TABLE, "-o", "--format", case_sensitive=False, help="Choose output format."
     ),
@@ -238,9 +245,10 @@ def cli(
 
     reports = collect_reports_parallel(
         dirs,
-        fetch=fetch,
+        fetch=fetch or pull_safe,
         dirty_only=dirty_only,
         include_ignored=include_ignored,
+        pull_safe=pull_safe,
         hook=hook,
         max_workers=parallel,  # None means auto-detect, 0 means sequential, N means N workers
     )
@@ -341,7 +349,7 @@ def _sort_reports(reports: List[RepoReport], *, sort: SortMode, reverse: bool) -
     reports.sort(key=lambda report: _report_sort_key(report, sort), reverse=reverse)
 
 
-def _report_sort_key(report: RepoReport, sort: SortMode) -> object:
+def _report_sort_key(report: RepoReport, sort: SortMode) -> SortKey:
     if sort is SortMode.DIR:
         return report.display_path.casefold()
     if sort is SortMode.PATH:

--- a/src/gitoverit/output/json.py
+++ b/src/gitoverit/output/json.py
@@ -12,6 +12,8 @@ def render_json(reports: Sequence[RepoReport]) -> str:
             "path": str(report.path),
             "display_path": report.display_path,
             "fetch_failed": report.fetch_failed,
+            "pull_failed": report.pull_failed,
+            "pulled": report.pulled,
             "status": render_status_segments(report.status_segments),
             "branch": report.branch,
             "remote": report.remote,

--- a/src/gitoverit/output/table.py
+++ b/src/gitoverit/output/table.py
@@ -653,6 +653,7 @@ def _status_key_main() -> Text:
     add("↑", "ahead", "green")
     add("↓", "behind", "bright_black")
     add("s", "submodules", "blue")
+    add("p", "pulled", "cyan")
 
     return text
 

--- a/src/gitoverit/reporting.py
+++ b/src/gitoverit/reporting.py
@@ -35,6 +35,8 @@ class RepoReport:
     modified: int = 0
     untracked: int = 0
     deleted: int = 0
+    pull_failed: bool = False
+    pulled: bool = False
 
     def status_text(self) -> Text:
         if not self.status_segments:
@@ -56,6 +58,23 @@ class ParsedStatus:
     has_conflicts: bool
 
 
+@dataclass
+class RepoState:
+    parsed: ParsedStatus
+    additions: int
+    deletions: int
+    ahead: int
+    behind: int
+    remote_ref: str | None
+    remote_url: str | None
+    branch_name: str
+    exceptional: bool
+    submodule_count: int
+    ident: str | None
+    latest_mtime: float | None
+    dirty: bool
+
+
 EXCEPTION_SENTINELS = (
     "MERGE_HEAD",
     "CHERRY_PICK_HEAD",
@@ -73,6 +92,7 @@ def collect_reports(
     fetch: bool,
     dirty_only: bool,
     include_ignored: bool = False,
+    pull_safe: bool = False,
     hook: HookProtocol | None = None,
 ) -> list[RepoReport]:
     # Backwards-compatible wrapper for sequential runs.
@@ -81,6 +101,7 @@ def collect_reports(
         fetch=fetch,
         dirty_only=dirty_only,
         include_ignored=include_ignored,
+        pull_safe=pull_safe,
         hook=hook,
         max_workers=0,
     )
@@ -104,6 +125,7 @@ def collect_reports_parallel(
     fetch: bool,
     dirty_only: bool,
     include_ignored: bool = False,
+    pull_safe: bool = False,
     hook: HookProtocol | None = None,
     max_workers: int | None = None,
 ) -> list[RepoReport]:
@@ -136,9 +158,16 @@ def collect_reports_parallel(
             for index, repo_path in enumerate(repo_paths, start=1):
                 statused_total = index
                 try:
-                    report = analyze_repository(repo_path, fetch=fetch)
+                    report = analyze_repository(
+                        repo_path,
+                        fetch=fetch,
+                        pull_safe=pull_safe,
+                    )
                     if not (
-                        dirty_only and not report.dirty and not report.fetch_failed
+                        dirty_only
+                        and not report.dirty
+                        and not report.fetch_failed
+                        and not report.pull_failed
                     ):
                         reports.append(report)
                 except Exception as exc:
@@ -177,7 +206,12 @@ def collect_reports_parallel(
                     if hook:
                         hook.discovering(repo_path)
 
-                    future = executor.submit(analyze_repository, repo_path, fetch)
+                    future = executor.submit(
+                        analyze_repository,
+                        repo_path,
+                        fetch,
+                        pull_safe,
+                    )
                     futures[future] = repo_path
 
                 if not futures:
@@ -195,7 +229,10 @@ def collect_reports_parallel(
                     try:
                         report = future.result()
                         if not (
-                            dirty_only and not report.dirty and not report.fetch_failed
+                            dirty_only
+                            and not report.dirty
+                            and not report.fetch_failed
+                            and not report.pull_failed
                         ):
                             reports.append(report)
                     except Exception as exc:
@@ -283,85 +320,130 @@ def _is_gitignored_by_parent(path: Path, known_repos: list[Path]) -> bool:
     return result.returncode == 0
 
 
-def analyze_repository(path: Path, fetch: bool) -> RepoReport:
+def analyze_repository(path: Path, fetch: bool, pull_safe: bool = False) -> RepoReport:
     repo = Repo(path)
     fetch_failed = False
+    pull_failed = False
+    pulled = False
 
-    if fetch and repo.remotes:
-        try:
-            result = subprocess.run(
-                ["git", "-C", str(path), "fetch", "--all"],
-                capture_output=True,
-                timeout=60,
-                env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
-            )
-            if result.returncode != 0:
-                fetch_failed = True
-        except (subprocess.TimeoutExpired, OSError):
+    if (fetch or pull_safe) and repo.remotes:
+        if not _run_git_operation(path, "fetch", "--all", timeout=60):
             fetch_failed = True
 
-    status = repo.git.status("--porcelain")
-    parsed = parse_status_porcelain(status)
+    state = _collect_repo_state(repo)
 
-    additions, deletions = diff_numstat_totals(repo)
+    if pull_safe and _can_pull_safely(state, fetch_failed=fetch_failed):
+        if _run_git_operation(path, "pull", "--ff-only", timeout=120):
+            pulled = True
+        else:
+            pull_failed = True
+        state = _collect_repo_state(repo)
 
-    ahead, behind, remote_ref, remote_url = compute_branch_tracking(repo)
-    branch_name = determine_branch(repo)
-
-    exceptional = has_exceptional_state(repo, parsed)
-    submodule_count = count_submodules(repo)
-
-    ident = read_git_ident(repo)
-    latest_mtime = latest_worktree_mtime(repo)
-
-    segments: list[tuple[str, str | None, str]] = []
-    if parsed.modified_count:
-        segments.append((f"{parsed.modified_count}m", "yellow", "core"))
-    if additions or deletions:
-        segments.append((f"(+{additions}/-{deletions})", "cyan", "plus_minus"))
-    if parsed.untracked_count:
-        segments.append((f"{parsed.untracked_count}u", "magenta", "core"))
-    if parsed.deleted_count:
-        segments.append((f"{parsed.deleted_count}d", "red", "core"))
-    if submodule_count:
-        segments.append((f"{submodule_count}s", "blue", "extras"))
-    if ahead:
-        segments.append((f"{ahead}\u2191", "green", "core"))
-    if behind:
-        segments.append((f"{behind}\u2193", "bright_black", "core"))
-    if exceptional:
-        segments.append(("!", "bold red", "core"))
-
-    dirty = bool(
-        parsed.modified_count
-        or additions
-        or deletions
-        or parsed.untracked_count
-        or parsed.deleted_count
-        or exceptional
-    )
+    segments = _render_repo_state_segments(state, pulled=pulled)
 
     display_path = relativize(path)
-    if fetch_failed:
+    if fetch_failed or pull_failed:
         display_path = f"! {display_path}"
 
     return RepoReport(
         path=path,
         display_path=display_path,
         fetch_failed=fetch_failed,
+        pull_failed=pull_failed,
+        pulled=pulled,
         status_segments=segments,
-        branch=branch_name,
-        remote=remote_ref or "-",
-        remote_url=remote_url or "-",
-        ident=ident,
-        dirty=dirty,
-        latest_mtime=latest_mtime,
+        branch=state.branch_name,
+        remote=state.remote_ref or "-",
+        remote_url=state.remote_url or "-",
+        ident=state.ident,
+        dirty=state.dirty,
+        latest_mtime=state.latest_mtime,
+        ahead=state.ahead,
+        behind=state.behind,
+        modified=state.parsed.modified_count,
+        untracked=state.parsed.untracked_count,
+        deleted=state.parsed.deleted_count,
+    )
+
+
+def _run_git_operation(path: Path, *args: str, timeout: int) -> bool:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), *args],
+            capture_output=True,
+            timeout=timeout,
+            env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
+def _collect_repo_state(repo: Repo) -> RepoState:
+    status = repo.git.status("--porcelain")
+    parsed = parse_status_porcelain(status)
+    additions, deletions = diff_numstat_totals(repo)
+    ahead, behind, remote_ref, remote_url = compute_branch_tracking(repo)
+    exceptional = has_exceptional_state(repo, parsed)
+    return RepoState(
+        parsed=parsed,
+        additions=additions,
+        deletions=deletions,
         ahead=ahead,
         behind=behind,
-        modified=parsed.modified_count,
-        untracked=parsed.untracked_count,
-        deleted=parsed.deleted_count,
+        remote_ref=remote_ref,
+        remote_url=remote_url,
+        branch_name=determine_branch(repo),
+        exceptional=exceptional,
+        submodule_count=count_submodules(repo),
+        ident=read_git_ident(repo),
+        latest_mtime=latest_worktree_mtime(repo),
+        dirty=bool(
+            parsed.modified_count
+            or additions
+            or deletions
+            or parsed.untracked_count
+            or parsed.deleted_count
+            or exceptional
+        ),
     )
+
+
+def _can_pull_safely(state: RepoState, *, fetch_failed: bool) -> bool:
+    return (
+        not fetch_failed
+        and state.behind > 0
+        and state.ahead == 0
+        and not state.dirty
+        and state.remote_ref is not None
+    )
+
+
+def _render_repo_state_segments(
+    state: RepoState,
+    *,
+    pulled: bool,
+) -> list[tuple[str, str | None, str]]:
+    segments: list[tuple[str, str | None, str]] = []
+    if state.parsed.modified_count:
+        segments.append((f"{state.parsed.modified_count}m", "yellow", "core"))
+    if state.additions or state.deletions:
+        segments.append((f"(+{state.additions}/-{state.deletions})", "cyan", "plus_minus"))
+    if state.parsed.untracked_count:
+        segments.append((f"{state.parsed.untracked_count}u", "magenta", "core"))
+    if state.parsed.deleted_count:
+        segments.append((f"{state.parsed.deleted_count}d", "red", "core"))
+    if state.submodule_count:
+        segments.append((f"{state.submodule_count}s", "blue", "extras"))
+    if state.ahead:
+        segments.append((f"{state.ahead}\u2191", "green", "core"))
+    if state.behind:
+        segments.append((f"{state.behind}\u2193", "bright_black", "core"))
+    if pulled:
+        segments.append(("p", "cyan", "extras"))
+    if state.exceptional:
+        segments.append(("!", "bold red", "core"))
+    return segments
 
 
 def parse_status_porcelain(output: str) -> ParsedStatus:

--- a/tests/test_gitoverit.py
+++ b/tests/test_gitoverit.py
@@ -1,3 +1,4 @@
+import json
 import io
 import os
 import time
@@ -8,16 +9,20 @@ from tempfile import TemporaryDirectory
 from git import Actor, Repo
 
 from gitoverit.cli import SortMode, _filter_reports, _print_reports, _sort_reports
+from gitoverit.output import render_json
 from gitoverit.output.table import DEFAULT_COLUMNS, parse_columns
 from gitoverit.reporting import (
     ParsedStatus,
     RepoReport,
+    analyze_repository,
     discover_repositories,
     has_exceptional_state,
     latest_worktree_mtime,
     parse_status_porcelain,
     simplify_url,
 )
+
+AUTHOR = Actor("Tester", "tester@example.com")
 
 
 class ParseStatusTests(unittest.TestCase):
@@ -58,8 +63,7 @@ class LatestWorktreeMtimeTests(unittest.TestCase):
             tracked = worktree / "tracked.txt"
             tracked.write_text("tracked")
             repo.index.add([str(tracked.relative_to(worktree))])
-            author = Actor("Tester", "tester@example.com")
-            repo.index.commit("initial", author=author, committer=author)
+            repo.index.commit("initial", author=AUTHOR, committer=AUTHOR)
 
             past_time = time.time() - 10_000
             os.utime(tracked, (past_time, past_time))
@@ -83,8 +87,7 @@ class ExceptionalStateTests(unittest.TestCase):
             tracked = worktree / "tracked.txt"
             tracked.write_text("tracked")
             repo.index.add([str(tracked.relative_to(worktree))])
-            author = Actor("Tester", "tester@example.com")
-            repo.index.commit("initial", author=author, committer=author)
+            repo.index.commit("initial", author=AUTHOR, committer=AUTHOR)
 
             rebase_head = Path(repo.git_dir) / "REBASE_HEAD"
             rebase_head.write_text(repo.head.commit.hexsha + "\n")
@@ -151,8 +154,7 @@ class DiscoverRepositoriesTests(unittest.TestCase):
             gitignore = parent / ".gitignore"
             gitignore.write_text("nested/\n")
             parent_repo.index.add([".gitignore"])
-            author = Actor("Tester", "tester@example.com")
-            parent_repo.index.commit("init", author=author, committer=author)
+            parent_repo.index.commit("init", author=AUTHOR, committer=AUTHOR)
 
             # Create a nested repo inside the gitignored directory
             nested = parent / "nested"
@@ -210,8 +212,7 @@ class DiscoverRepositoriesTests(unittest.TestCase):
             gitignore = parent / ".gitignore"
             gitignore.write_text("vendor/\n")
             parent_repo.index.add([".gitignore"])
-            author = Actor("Tester", "tester@example.com")
-            parent_repo.index.commit("init", author=author, committer=author)
+            parent_repo.index.commit("init", author=AUTHOR, committer=AUTHOR)
 
             # Create vendor/lib which is a repo, under a gitignored path
             vendor_lib = parent / "vendor" / "lib"
@@ -438,6 +439,78 @@ class SortReportsTests(unittest.TestCase):
             ["third", "second", "first"],
         )
 
+class PullSafeTests(unittest.TestCase):
+    def _commit_file(self, repo: Repo, relative_path: str, content: str, message: str) -> None:
+        worktree = Path(repo.working_tree_dir or "")
+        path = worktree / relative_path
+        path.write_text(content)
+        repo.index.add([relative_path])
+        repo.index.commit(message, author=AUTHOR, committer=AUTHOR)
+
+    def _clone_remote_triplet(self, tmpdir: str) -> tuple[Repo, Repo]:
+        remote = Path(tmpdir) / "remote.git"
+        Repo.init(remote, bare=True)
+
+        seed = Repo.clone_from(str(remote), Path(tmpdir) / "seed")
+        self._commit_file(seed, "README.md", "seed\n", "seed")
+        seed.git.push("--set-upstream", "origin", seed.active_branch.name)
+
+        local = Repo.clone_from(str(remote), Path(tmpdir) / "local")
+        other = Repo.clone_from(str(remote), Path(tmpdir) / "other")
+        return local, other
+
+    def test_pull_safe_fast_forwards_clean_repo(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            local, other = self._clone_remote_triplet(tmpdir)
+            self._commit_file(other, "README.md", "remote change\n", "remote change")
+            other.git.push("origin", other.active_branch.name)
+
+            report = analyze_repository(Path(local.working_tree_dir or ""), fetch=False, pull_safe=True)
+
+            self.assertTrue(report.pulled)
+            self.assertFalse(report.pull_failed)
+            self.assertEqual(report.behind, 0)
+            self.assertFalse(report.dirty)
+            self.assertIn(("p", "cyan", "extras"), report.status_segments)
+
+            payload = json.loads(render_json([report]))[0]
+            self.assertTrue(payload["pulled"])
+            self.assertFalse(payload["pull_failed"])
+
+    def test_pull_safe_skips_dirty_repo(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            local, other = self._clone_remote_triplet(tmpdir)
+            self._commit_file(other, "README.md", "remote change\n", "remote change")
+            other.git.push("origin", other.active_branch.name)
+
+            dirty_path = Path(local.working_tree_dir or "") / "local.txt"
+            dirty_path.write_text("dirty\n")
+            before = local.head.commit.hexsha
+
+            report = analyze_repository(Path(local.working_tree_dir or ""), fetch=False, pull_safe=True)
+
+            self.assertFalse(report.pulled)
+            self.assertFalse(report.pull_failed)
+            self.assertEqual(report.behind, 1)
+            self.assertTrue(report.dirty)
+            self.assertEqual(local.head.commit.hexsha, before)
+
+    def test_pull_safe_skips_diverged_repo(self) -> None:
+        with TemporaryDirectory() as tmpdir:
+            local, other = self._clone_remote_triplet(tmpdir)
+            self._commit_file(other, "README.md", "remote change\n", "remote change")
+            other.git.push("origin", other.active_branch.name)
+
+            self._commit_file(local, "local.txt", "local change\n", "local change")
+            before = local.head.commit.hexsha
+
+            report = analyze_repository(Path(local.working_tree_dir or ""), fetch=False, pull_safe=True)
+
+            self.assertFalse(report.pulled)
+            self.assertFalse(report.pull_failed)
+            self.assertEqual(report.ahead, 1)
+            self.assertEqual(report.behind, 1)
+            self.assertEqual(local.head.commit.hexsha, before)
 
 class PrintReportsTests(unittest.TestCase):
     def _make_report(self, **kwargs: object) -> RepoReport:

--- a/tests/test_table_output.py
+++ b/tests/test_table_output.py
@@ -50,6 +50,7 @@ class TableKeyOutputTests(unittest.TestCase):
         self.assertIn("↑\u00A0ahead", output)
         self.assertIn("↓\u00A0behind", output)
         self.assertIn("s\u00A0submodules", output)
+        self.assertIn("p\u00A0pulled", output)
 
     def test_exceptional_key_only_when_bang_present(self) -> None:
         console_no_bang = Console(record=True, width=80)


### PR DESCRIPTION
## Summary
Add `--pull-safe`, which implies fetch and only runs `git pull --ff-only` for repositories that are behind upstream, not ahead, and otherwise clean.

Fixes #4.

## Why
A plain batch pull is too easy to turn into merge conflicts or unwanted merge commits. The safer behavior is to pull only when the repo already looks like a clean fast-forward candidate.

## User impact
Users can now run `gitoverit --pull-safe` to fast-forward safe repos in place. Repositories that are dirty, diverged, or otherwise not good pull candidates are left alone. Pulled repos are marked with `p` in the status key, and operation failures are still surfaced.

## Root cause
The original issue proposed a broad `--pull`, but that would have encouraged risky pulls on repos with local state that should be handled manually.

## Validation
- `uv run tasks/test`
- `uv run tasks/check`
- `uv run gitoverit --help`
